### PR TITLE
Use new API, because current is deprecated

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formula-1-season-standings",
-  "version": "3.0.16",
+  "version": "3.0.17",
   "description": "",
   "scripts": {
     "dev": "next dev -p 8100",

--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -1,1 +1,2 @@
-export const API_ENDPOINT = 'https://ergast.com/api/f1/';
+export const API_ENDPOINT =
+  process.env.NEXT_PUBLIC_API_ENDPOINT || 'https://api.jolpi.ca/ergast/f1/';


### PR DESCRIPTION
This pull request includes a change to the `src/config/api.ts` file. The change updates the `API_ENDPOINT` to use an environment variable if available, otherwise it defaults to a new URL.

* [`src/config/api.ts`](diffhunk://#diff-3a437d8dd17b9bb777b258b4b65450a23f663879ed267c19edd6727900583575L1-R2): Modified the `API_ENDPOINT` to use `process.env.NEXT_PUBLIC_API_ENDPOINT` if defined, falling back to 'https://api.jolpi.ca/ergast/f1/' as the default.