### PR TITLE
Update renovate.json to disable auto rebase

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,5 @@
   "labels": [
     "[bot] renovate"
   ],
-  "prConcurrentLimit": 10,
-  "rebaseWhen": "auto"
+  "rebaseWhen": "never"
 }


### PR DESCRIPTION
This pull request includes a minor change to the `renovate.json` configuration file. The change modifies the `rebaseWhen` property to "never" and removes the `prConcurrentLimit` property.

* [`renovate.json`](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L13-R13): Changed `rebaseWhen` to "never" and removed `prConcurrentLimit`.